### PR TITLE
include esphome.h

### DIFF
--- a/components/esp32_camera_web_server/camera_web_server.cpp
+++ b/components/esp32_camera_web_server/camera_web_server.cpp
@@ -1,5 +1,6 @@
 #ifdef USE_ESP32
 
+#include "esphome.h"
 #include "camera_web_server.h"
 #include "esphome/core/application.h"
 #include "esphome/core/helpers.h"


### PR DESCRIPTION
Resolves `error: 'millis' was not declared in this scope`