### PR TITLE
Add compatibility for the espidf framework.

### DIFF
--- a/components/inode_ble/inode_ble.cpp
+++ b/components/inode_ble/inode_ble.cpp
@@ -1,7 +1,6 @@
 #include "inode_ble.h"
 #include "esphome/core/log.h"
 
-#ifdef ARDUINO_ARCH_ESP32
 using namespace esphome;
 
 static const char *TAG = "inode_ble";
@@ -84,5 +83,3 @@ void iNodeMeterSensor::dump_config() {
 
   LOG_SENSOR("  ", "Light Level", this->light_level_);
 }
-
-#endif

--- a/components/inode_ble/inode_ble.h
+++ b/components/inode_ble/inode_ble.h
@@ -4,8 +4,6 @@
 #include "esphome/components/sensor/sensor.h"
 #include "esphome/components/esp32_ble_tracker/esp32_ble_tracker.h"
 
-#ifdef ARDUINO_ARCH_ESP32
-
 struct iNodeMeterData {
   unsigned short rawAvg;
   unsigned int rawSum;
@@ -35,18 +33,16 @@ public:
   INODE_SET_METHOD(uint64_t, address, 0);
   INODE_SET_METHOD(int, constant, 1);
 
-  INODE_SET_METHOD(esphome::sensor::Sensor *, avg_raw, 0);
-  INODE_SET_METHOD(esphome::sensor::Sensor *, avg_w, 0);
-  INODE_SET_METHOD(esphome::sensor::Sensor *, avg_dm3, 0);
+  INODE_SET_METHOD(esphome::sensor::Sensor *, avg_raw, nullptr);
+  INODE_SET_METHOD(esphome::sensor::Sensor *, avg_w, nullptr);
+  INODE_SET_METHOD(esphome::sensor::Sensor *, avg_dm3, nullptr);
 
-  INODE_SET_METHOD(esphome::sensor::Sensor *, total_raw, 0);
-  INODE_SET_METHOD(esphome::sensor::Sensor *, total_kwh, 0);
-  INODE_SET_METHOD(esphome::sensor::Sensor *, total_dm3, 0);
+  INODE_SET_METHOD(esphome::sensor::Sensor *, total_raw, nullptr);
+  INODE_SET_METHOD(esphome::sensor::Sensor *, total_kwh, nullptr);
+  INODE_SET_METHOD(esphome::sensor::Sensor *, total_dm3, nullptr);
 
-  INODE_SET_METHOD(esphome::sensor::Sensor *, battery_level, 0);
-  INODE_SET_METHOD(esphome::sensor::Sensor *, battery_level_v, 0);
+  INODE_SET_METHOD(esphome::sensor::Sensor *, battery_level, nullptr);
+  INODE_SET_METHOD(esphome::sensor::Sensor *, battery_level_v, nullptr);
 
-  INODE_SET_METHOD(esphome::sensor::Sensor *, light_level, 0);
+  INODE_SET_METHOD(esphome::sensor::Sensor *, light_level, nullptr);
 };
-
-#endif


### PR DESCRIPTION
Removing #ifdef ARDUINO_ARCH_ESP32 and updating the INODE_SET_METHOD macro to use nullptr as the default value for the sensor pointers instead of 0.